### PR TITLE
Fix: Linting and solve requiresMainQueueSetup warnings

### DIFF
--- a/ios/RNAlert/RNAlert.m
+++ b/ios/RNAlert/RNAlert.m
@@ -6,4 +6,8 @@ RCT_EXTERN_METHOD(show:(NSDictionary *)options)
 
 RCT_EXTERN_METHOD(dismissAll)
 
++ (BOOL) requiresMainQueueSetup {
+  return NO;
+}
+
 @end

--- a/ios/RNConfetti/RNConfetti.m
+++ b/ios/RNConfetti/RNConfetti.m
@@ -6,4 +6,8 @@ RCT_EXTERN_METHOD(start:(NSDictionary *)options)
 
 RCT_EXTERN_METHOD(stop)
 
++ (BOOL) requiresMainQueueSetup {
+  return NO;
+}
+
 @end

--- a/ios/RNToast/RNToast.m
+++ b/ios/RNToast/RNToast.m
@@ -4,4 +4,8 @@
 
 RCT_EXTERN_METHOD(show:(NSDictionary *)options)
 
++ (BOOL) requiresMainQueueSetup {
+  return NO;
+}
+
 @end

--- a/src/Confetti.ts
+++ b/src/Confetti.ts
@@ -14,5 +14,5 @@ async function stop() {
 
 export const Confetti = {
   start,
-  stop
-}
+  stop,
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,3 @@
-export * from './Confetti'
-export * from './Toast'
-export * from './Alert'
+export * from './Confetti';
+export * from './Toast';
+export * from './Alert';


### PR DESCRIPTION
This PR resolves warning caused by `requiresMainQueueSetup` not being explicitly defined.

Also some linting fixes with prettier.